### PR TITLE
Fix O(pop_size) Python-level max/min in StandardPipeline.show_details

### DIFF
--- a/src/evogp/pipeline/standard.py
+++ b/src/evogp/pipeline/standard.py
@@ -93,8 +93,8 @@ class StandardPipeline(BasePipeline):
         ]
 
         max_f, min_f, mean_f, std_f = (
-            max(valid_fitness),
-            min(valid_fitness),
+            torch.max(valid_fitness),
+            torch.min(valid_fitness),
             torch.mean(valid_fitness),
             torch.std(valid_fitness),
         )


### PR DESCRIPTION

Replaces Python builtin max/min over the fitness tensor with torch.max/torch.min; at pop 1M this reduces default-settings generation time from ~2.5 s to ~0.09 s with identical output. From [this](https://github.com/EMI-Group/evogp/issues/13).
